### PR TITLE
Add espresso flag

### DIFF
--- a/params/config.go
+++ b/params/config.go
@@ -271,6 +271,8 @@ type ChainConfig struct {
 	DAOForkBlock   *big.Int `json:"daoForkBlock,omitempty"`   // TheDAO hard-fork switch block (nil = no fork)
 	DAOForkSupport bool     `json:"daoForkSupport,omitempty"` // Whether the nodes supports or opposes the DAO hard-fork
 
+	Espresso bool `json:"espresso,omitempty"` // Whether the chain is using the espresso sequencer
+
 	// EIP150 implements the Gas price changes (https://github.com/ethereum/EIPs/issues/150)
 	EIP150Block *big.Int `json:"eip150Block,omitempty"` // EIP150 HF block (nil = no fork)
 	EIP155Block *big.Int `json:"eip155Block,omitempty"` // EIP155 HF block


### PR DESCRIPTION
Necessary for validators. When this flag is `true`, validators will know to check the state transition against the hotshot commitment corresponding to an unvalidated batch. 